### PR TITLE
Release camera on server shutdown

### DIFF
--- a/toyxyz_test_nodes.py
+++ b/toyxyz_test_nodes.py
@@ -79,6 +79,10 @@ class CaptureWebcam:
             self.capture = cv2.VideoCapture(webcam_index)
             return self.capture
 
+        if (self.webcam_index != webcam_index):
+            # make sure to release previous
+            self.capture.release()
+            
         if self.capture.isOpened() and self.webcam_index == webcam_index:
             return self.capture
 

--- a/toyxyz_test_nodes.py
+++ b/toyxyz_test_nodes.py
@@ -124,6 +124,12 @@ class CaptureWebcam:
     def IS_CHANGED(cls):
 
         return
+
+
+    # Deleting (release camera on server shutdown)
+    def __del__(self):
+        if (self.capture != None):
+            self.capture.release()
         
 class LoadWebcamImage:
 


### PR DESCRIPTION
I don't know how to get the camera to release when the node is deleted or when workflow changes. It seems there is no hook in comfy for this. So for now it means that the camera will be locked into comfy for as long as the server is online... not ideal.